### PR TITLE
Fix for Ubuntu 14.04 and OpenSSL 1.0.1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,7 +6,7 @@ disabled_rules:
     - trailing_newline
     - force_cast
     - function_body_length
-    - indentifier_name
+    - identifier_name
     - line_length
     - trailing_whitespace
     - type_name

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,10 +2,11 @@ included:
     - Sources
     - Tests
 disabled_rules:
+    - nesting
     - trailing_newline
     - force_cast
     - function_body_length
-    - variable_name
+    - indentifier_name
     - line_length
     - trailing_whitespace
     - type_name

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Travis CI build file for BlueRSA
+
+# whitelist (branches that should be built)
+branches:
+  only:
+    - master
+    - develop
+    - /^issue.*$/
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.0.3
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-23-a
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04
+    - os: osx
+      osx_image: xcode9.2
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.0.3
+    - os: osx
+      osx_image: xcode9.4
+      sudo: required
+
+before_install:
+  - git clone https://github.com/IBM-Swift/Package-Builder.git
+
+script:
+  - openssl version
+  - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         )
     ],
 	dependencies: [
-        .package(url: CryptoLibUrl, .branch(CryptoLibVersion))
+        .package(url: CryptoLibUrl, CryptoLibVersion)
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -25,12 +25,12 @@ import PackageDescription
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 	
     let CryptoLibUrl = "https://github.com/IBM-Swift/CommonCrypto.git"
-    let CryptoLibVersion: Version = "1.0.0"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor("1.0.0")
 	
 #elseif os(Linux)
 	
 	let CryptoLibUrl = "https://github.com/IBM-Swift/OpenSSL.git"
-    let CryptoLibVersion: String = "issue.BlueRSAFailure"
+    let CryptoLibVersion: Package.Dependency.Requirement = .branch("issue.BlueRSAFailure")
 	
 #else
 	

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ import PackageDescription
 #elseif os(Linux)
 	
 	let CryptoLibUrl = "https://github.com/IBM-Swift/OpenSSL.git"
-    let CryptoLibVersion: Version = "1.0.0"
+    let CryptoLibVersion: String = "issue.BlueRSAFailure"
 	
 #else
 	
@@ -48,7 +48,7 @@ let package = Package(
         )
     ],
 	dependencies: [
-        .package(url: CryptoLibUrl, from: CryptoLibVersion)
+        .package(url: CryptoLibUrl, .branch(CryptoLibVersion))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ import PackageDescription
 #elseif os(Linux)
 	
 	let CryptoLibUrl = "https://github.com/IBM-Swift/OpenSSL.git"
-    let CryptoLibVersion: Package.Dependency.Requirement = .branch("issue.BlueRSAFailure")
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.1")
 	
 #else
 	

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ import PackageDescription
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 	
     let CryptoLibUrl = "https://github.com/IBM-Swift/CommonCrypto.git"
-    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor("1.0.0")
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.0")
 	
 #elseif os(Linux)
 	

--- a/Sources/CryptorRSA/CryptorRSA.swift
+++ b/Sources/CryptorRSA/CryptorRSA.swift
@@ -615,7 +615,7 @@ public class CryptorRSA {
 
                 // Unlike other return values above, this return indicates if signature verifies or not
                 rc = signature.data.withUnsafeBytes({ (sig: UnsafePointer<UInt8>) -> Int32 in
-                    return EVP_DigestVerifyFinal(md_ctx, sig, signature.data.count)
+                    return SSL_EVP_digestVerifyFinal_wrapper(md_ctx, sig, signature.data.count)
                 })
                 
                 return (rc == 1) ? true : false

--- a/Sources/CryptorRSA/CryptorRSA.swift
+++ b/Sources/CryptorRSA/CryptorRSA.swift
@@ -224,7 +224,7 @@ public class CryptorRSA {
 			#if os(Linux)
                 
                 // Convert RSA key to EVP
-                var  evp_key = EVP_PKEY_new()
+                var evp_key = EVP_PKEY_new()
                 var rc = EVP_PKEY_set1_RSA(evp_key, key.reference)
                 guard rc == 1 else {
                     let source = "Couldn't create key reference from key data"
@@ -275,7 +275,7 @@ public class CryptorRSA {
                         
                         throw Error(code: ERR_ENCRYPTION_FAILED, reason: reason)
                     }
-                    throw Error(code: ERR_ENCRYPTION_FAILED , reason: source + ": No OpenSSL error reported.")
+                    throw Error(code: ERR_ENCRYPTION_FAILED, reason: source + ": No OpenSSL error reported.")
                 }
                 
                 // EVP_SealUpdate is a complex macros and therefore the compiler doesnt
@@ -292,9 +292,9 @@ public class CryptorRSA {
                         
                         throw Error(code: ERR_ENCRYPTION_FAILED, reason: reason)
                     }
-                    throw Error(code: ERR_ENCRYPTION_FAILED , reason: source + ": No OpenSSL error reported.")
+                    throw Error(code: ERR_ENCRYPTION_FAILED, reason: source + ": No OpenSSL error reported.")
                 }
-                encLength = encLength + processedLength
+                encLength += processedLength
                 
                 let cipher = Data(bytes: encrypted, count: Int(encLength))
                 let ekFinal = Data(bytes: ek!, count: Int(encKeyLength))
@@ -347,7 +347,7 @@ public class CryptorRSA {
 			#if os(Linux)
 				
                 // Convert RSA key to EVP
-                var  evp_key = EVP_PKEY_new()
+                var evp_key = EVP_PKEY_new()
                 var status = EVP_PKEY_set1_RSA(evp_key, key.reference)
                 guard status == 1 else {
                     let source = "Couldn't create key reference from key data"
@@ -402,7 +402,7 @@ public class CryptorRSA {
                         
                         throw Error(code: ERR_DECRYPTION_FAILED, reason: reason)
                     }
-                    throw Error(code: ERR_DECRYPTION_FAILED , reason: source + ": No OpenSSL error reported.")
+                    throw Error(code: ERR_DECRYPTION_FAILED, reason: source + ": No OpenSSL error reported.")
                 }
                 
                 // EVP_OpenUpdate is a complex macros and therefore the compiler doesnt
@@ -419,9 +419,9 @@ public class CryptorRSA {
                         
                         throw Error(code: ERR_DECRYPTION_FAILED, reason: reason)
                     }
-                    throw Error(code: ERR_DECRYPTION_FAILED , reason: source + ": No OpenSSL error reported.")
+                    throw Error(code: ERR_DECRYPTION_FAILED, reason: source + ": No OpenSSL error reported.")
                 }
-                decMsgLen = decMsgLen + processedLen
+                decMsgLen += processedLen
                 
                 return PlaintextData(with: Data(bytes: decrypted, count: Int(decMsgLen)))
                 
@@ -479,7 +479,7 @@ public class CryptorRSA {
                 }
                 
                 // convert RSA key to EVP
-                let  evp_key = EVP_PKEY_new()
+                let evp_key = EVP_PKEY_new()
                 var rc = EVP_PKEY_set1_RSA(evp_key, key.reference)
                 guard rc == 1 else {
                     let source = "Couldn't create key reference from key data"
@@ -579,7 +579,7 @@ public class CryptorRSA {
                 }
                 
                 // convert RSA key to EVP
-                let  evp_key = EVP_PKEY_new()
+                let evp_key = EVP_PKEY_new()
                 var rc = EVP_PKEY_set1_RSA(evp_key, key.reference)
                 guard rc == 1 else {
                     let source = "Couldn't create key reference from key data"

--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -693,7 +693,7 @@ public extension CryptorRSA {
 				let start = pemString.index(pemString.startIndex, offsetBy: match.location)
 				let end = pemString.index(start, offsetBy: match.length)
 				
-				let range = Range<String.Index>(start..<end)
+				let range = start..<end
 				
 				let thisKey = pemString[range]
 				

--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -357,19 +357,19 @@ public extension CryptorRSA {
             }
             let cert = PEM_read_bio_X509(certbio, nil, nil, nil)
             
-            if (cert == nil) {
+            if cert == nil {
                 print("Error loading cert into memory\n")
                 throw Error(code: ERR_CREATE_CERT_FAILED, reason: "Error loading cert into memory.")
             }
             
             // Extract the certificate's public key data.
             let evp_key = X509_get_pubkey(cert)
-            if ( evp_key == nil) {
+            if evp_key == nil {
                 throw Error(code: ERR_CREATE_CERT_FAILED, reason: "Error getting public key from certificate")
             }
 
             let key = EVP_PKEY_get1_RSA( evp_key)
-            if ( key == nil) {
+            if key == nil {
                 throw Error(code: ERR_CREATE_CERT_FAILED, reason: "Error getting public key from certificate")
             }
             defer {

--- a/Sources/CryptorRSA/CryptorRSAUtilities.swift
+++ b/Sources/CryptorRSA/CryptorRSAUtilities.swift
@@ -316,7 +316,7 @@ extension String {
 		for character in self {
 			collectedCharacters.append(character)
 			count += 1
-			if (count == length) {
+			if count == length {
 				// Reached the desired length
 				count = 0
 				result.append(String(collectedCharacters))

--- a/Tests/CryptorRSATests/CryptorRSATests.swift
+++ b/Tests/CryptorRSATests/CryptorRSATests.swift
@@ -480,9 +480,11 @@ class CryptorRSATests: XCTestCase {
             -----END PUBLIC KEY-----
             """
         
-        let tokenPublicKey = try CryptorRSA.createPublicKey(withPEM: certificatePEM)
+        guard let tokenPublicKey = try? CryptorRSA.createPublicKey(withPEM: certificatePEM) else {
+            XCTFail("Public ket not made")
+            return
+        }
 
-        XCTAssertNotNil(tokenPublicKey)
         XCTAssertTrue(tokenPublicKey.type == .publicType)
         
         let token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJhcHBJZC0xNTA0Njg1OTYxMDAwIn0.eyJpc3MiOiJhcHBpZC1vYXV0aC5uZy5ibHVlbWl4Lm5ldCIsImF1ZCI6IjUzOGU4NTI2YTcwNDdjMWM5ZTEzNDZhYzQ1MjA2NmQxYmE1ZmQzNTEiLCJleHAiOjE1MTgxOTkzNTgsInRlbmFudCI6ImQ3YmMzMjJjLWIyMjQtNDFjMS05MWVhLWZjNjM4YWUyYWQ0ZCIsImlhdCI6MTUxODE5NTc1OCwiZW1haWwiOiJhYXJvbi5saWJlcmF0b3JlQGdtYWlsLmNvbSIsIm5hbWUiOiJBYXJvbiBMaWJlcmF0b3JlIiwicGljdHVyZSI6Imh0dHBzOi8vbGgzLmdvb2dsZXVzZXJjb250ZW50LmNvbS8tWGRVSXFkTWtDV0EvQUFBQUFBQUFBQUkvQUFBQUFBQUFBQUEvNDI1MnJzY2J2NU0vcGhvdG8uanBnIiwic3ViIjoiNGZiOTY0NDUtMGIzYy00Mzg2LWI3MmEtNTk2YmIzYTlkNDUwIiwiaWRlbnRpdGllcyI6W3sicHJvdmlkZXIiOiJnb29nbGUiLCJpZCI6IjEwODQ2MDkwMTMxMTMxNzgyOTg4NCJ9XSwiYW1yIjpbImdvb2dsZSJdLCJvYXV0aF9jbGllbnQiOnsibmFtZSI6IldhdHNvbiBUb25lIEFuYWx5emVyIFJLQUpHIiwidHlwZSI6Im1vYmlsZWFwcCIsInNvZnR3YXJlX2lkIjoiY29tLmlibS5XYXRzb25Ub25lQW5hbHl6ZXJSS0FKRyIsInNvZnR3YXJlX3ZlcnNpb24iOiIxLjAiLCJkZXZpY2VfaWQiOiI3QTk2QjJDQi1DNkI4LTRCNTYtQjA0Ri1FMTMwQjZDMkUxMUMiLCJkZXZpY2VfbW9kZWwiOiJpUGhvbmUiLCJkZXZpY2Vfb3MiOiJpT1MiLCJkZXZpY2Vfb3NfdmVyc2lvbiI6IjExLjIifX0.RTK5wV0b0mtbRayKg9IdGCnGXoA7bn4Gdx-YIQjaaELWJwpla2x1R1hMvL5It-MKMt_pyejzkdoTKR3v_VF4IMwnBWz83d0u6TVs28TbrgHAkXy6sAypIfEKc4gLOSHXkUBYREH2pbJSguxZNTwqKe_PKRSYtG0QrtffPUsESfnGkdfHdUsSigMjX5s5En8fLCGiNSQF2uyYREDFE6T0w5P3W5MR_Scloyhik1q7nv91PzlJ6Rn9_0F12zjzvPMTt7bobTdokaFVPcqjFWHJc4YCw-bzdBCxtzHxf3oVXeJzCzPNb_nOehZu-u7ue54NbYwcoZ_bokmsjCnQbFE_QA"
@@ -504,12 +506,10 @@ class CryptorRSATests: XCTestCase {
         sig = sig.replacingOccurrences(of: "-", with: "+")
         sig = sig.replacingOccurrences(of: "_", with: "/")
         
-        guard let sigData: Data = Data(base64Encoded: sig) else {
-            XCTFail()
+        guard let sigData = Data(base64Encoded: sig) else {
+            XCTFail("Unable to create Signature Data")
             return
         }
-        
-        XCTAssertNotNil(sigData)
         
         let message = CryptorRSA.createPlaintext(with: messageData)
         XCTAssertNotNil(message)

--- a/Tests/CryptorRSATests/CryptorRSATests.swift
+++ b/Tests/CryptorRSATests/CryptorRSATests.swift
@@ -525,10 +525,21 @@ class CryptorRSATests: XCTestCase {
 	
 	static public func pemKeyString(name: String) -> String {
 		
-        let path = CryptorRSATests.getFilePath(for: name, ofType: "pem")
+        guard let path = CryptorRSATests.getFilePath(for: name, ofType: "pem") else {
+            XCTFail("Could not create pemKeyString")
+            return "Error"
+        }
+        
         XCTAssertNotNil(path)
         
-        return (try! String(contentsOfFile: path!.path, encoding: String.Encoding.utf8))
+        guard let returnValue: String = try? String(contentsOfFile: path.path, encoding: String.Encoding.utf8) else {
+            XCTFail("Could not create returnValue")
+            return "Error"
+        }
+        
+        XCTAssertNotNil(returnValue)
+        
+        return returnValue
 	}
 	
 	static public func derKeyData(name: String) -> Data {

--- a/Tests/CryptorRSATests/CryptorRSATests.swift
+++ b/Tests/CryptorRSATests/CryptorRSATests.swift
@@ -308,9 +308,9 @@ class CryptorRSATests: XCTestCase {
 	}
 
 	// MARK: Encyption/Decryption Tests
-	
-    let publicKey: CryptorRSA.PublicKey = try! CryptorRSATests.publicKey(name: "public")
-    let privateKey: CryptorRSA.PrivateKey = try! CryptorRSATests.privateKey(name: "private")
+    
+    let publicKey: CryptorRSA.PublicKey? = try? CryptorRSATests.publicKey(name: "public")
+    let privateKey: CryptorRSA.PrivateKey? = try? CryptorRSATests.privateKey(name: "private")
 	
 	func test_simpleEncryption() throws {
 		
@@ -326,7 +326,13 @@ class CryptorRSATests: XCTestCase {
 			print("Testing algorithm: \(name)")
 			let str = "Plain Text"
 			let plainText = try CryptorRSA.createPlaintext(with: str, using: .utf8)
-		
+            
+            guard let publicKey = self.publicKey,
+                  let privateKey = self.privateKey else {
+                XCTFail("Could not find key")
+                return
+            }
+            
 			let encrypted = try plainText.encrypted(with: publicKey, algorithm: algorithm)
 			XCTAssertNotNil(encrypted)
 			let decrypted = try encrypted!.decrypted(with: privateKey, algorithm: algorithm)
@@ -352,6 +358,12 @@ class CryptorRSATests: XCTestCase {
 			let str = [String](repeating: "a", count: 9999).joined(separator: "")
 			let plainText = try CryptorRSA.createPlaintext(with: str, using: .utf8)
 		
+            guard let publicKey = self.publicKey,
+                let privateKey = self.privateKey else {
+                    XCTFail("Could not find key")
+                    return
+            }
+            
 			let encrypted = try plainText.encrypted(with: publicKey, algorithm: algorithm)
 			XCTAssertNotNil(encrypted)
 			let decrypted = try encrypted!.decrypted(with: privateKey, algorithm: algorithm)
@@ -377,6 +389,12 @@ class CryptorRSATests: XCTestCase {
 			let data = CryptorRSATests.randomData(count: 2048)
 			let plainData = CryptorRSA.createPlaintext(with: data)
 		
+            guard let publicKey = self.publicKey,
+                let privateKey = self.privateKey else {
+                    XCTFail("Could not find key")
+                    return
+            }
+            
 			let encrypted = try plainData.encrypted(with: publicKey, algorithm: algorithm)
 			XCTAssertNotNil(encrypted)
 			let decrypted = try encrypted!.decrypted(with: privateKey, algorithm: algorithm)
@@ -395,6 +413,12 @@ class CryptorRSATests: XCTestCase {
 		                                              (.sha256, ".sha256"),
 		                                              (.sha384, ".sha384"),
 		                                              (.sha512, ".sha512")]
+        guard let publicKey = self.publicKey,
+            let privateKey = self.privateKey else {
+                XCTFail("Could not find key")
+                return
+        }
+        
 		// Test all the algorithms available...
 		for (algorithm, name) in algorithms {
 			
@@ -416,6 +440,13 @@ class CryptorRSATests: XCTestCase {
 		                                              (.sha256, ".sha256"),
 		                                              (.sha384, ".sha384"),
 		                                              (.sha512, ".sha512")]
+        
+        guard let publicKey = self.publicKey,
+            let privateKey = self.privateKey else {
+                XCTFail("Could not find key")
+                return
+        }
+        
 		// Test all the algorithms available...
 		for (algorithm, name) in algorithms {
 			
@@ -445,11 +476,12 @@ class CryptorRSATests: XCTestCase {
             -----END PUBLIC KEY-----
             """
         
-        let tokenPublicKey = try? CryptorRSA.createPublicKey(withPEM: certificatePEM)
+        let tokenPublicKey = try CryptorRSA.createPublicKey(withPEM: certificatePEM)
+
         XCTAssertNotNil(tokenPublicKey)
-        XCTAssertTrue(tokenPublicKey!.type == .publicType)
+        XCTAssertTrue(tokenPublicKey.type == .publicType)
         
-        let token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJhcHBJZC0xNTA0Njg1OTYxMDAwIn0.eyJpc3MiOiJhcHBpZC1vYXV0aC5uZy5ibHVlbWl4Lm5ldCIsImF1ZCI6IjUzOGU4NTI2YTcwNDdjMWM5ZTEzNDZhYzQ1MjA2NmQxYmE1ZmQzNTEiLCJleHAiOjE1MTgxOTkzNTgsInRlbmFudCI6ImQ3YmMzMjJjLWIyMjQtNDFjMS05MWVhLWZjNjM4YWUyYWQ0ZCIsImlhdCI6MTUxODE5NTc1OCwiZW1haWwiOiJhYXJvbi5saWJlcmF0b3JlQGdtYWlsLmNvbSIsIm5hbWUiOiJBYXJvbiBMaWJlcmF0b3JlIiwicGljdHVyZSI6Imh0dHBzOi8vbGgzLmdvb2dsZXVzZXJjb250ZW50LmNvbS8tWGRVSXFkTWtDV0EvQUFBQUFBQUFBQUkvQUFBQUFBQUFBQUEvNDI1MnJzY2J2NU0vcGhvdG8uanBnIiwic3ViIjoiNGZiOTY0NDUtMGIzYy00Mzg2LWI3MmEtNTk2YmIzYTlkNDUwIiwiaWRlbnRpdGllcyI6W3sicHJvdmlkZXIiOiJnb29nbGUiLCJpZCI6IjEwODQ2MDkwMTMxMTMxNzgyOTg4NCJ9XSwiYW1yIjpbImdvb2dsZSJdLCJvYXV0aF9jbGllbnQiOnsibmFtZSI6IldhdHNvbiBUb25lIEFuYWx5emVyIFJLQUpHIiwidHlwZSI6Im1vYmlsZWFwcCIsInNvZnR3YXJlX2lkIjoiY29tLmlibS5XYXRzb25Ub25lQW5hbHl6ZXJSS0FKRyIsInNvZnR3YXJlX3ZlcnNpb24iOiIxLjAiLCJkZXZpY2VfaWQiOiI3QTk2QjJDQi1DNkI4LTRCNTYtQjA0Ri1FMTMwQjZDMkUxMUMiLCJkZXZpY2VfbW9kZWwiOiJpUGhvbmUiLCJkZXZpY2Vfb3MiOiJpT1MiLCJkZXZpY2Vfb3NfdmVyc2lvbiI6IjExLjIifX0.RTK5wV0b0mtbRayKg9IdGCnGXoA7bn4Gdx-YIQjaaELWJwpla2x1R1hMvL5It-MKMt_pyejzkdoTKR3v_VF4IMwnBWz83d0u6TVs28TbrgHAkXy6sAypIfEKc4gLOSHXkUBYREH2pbJSguxZNTwqKe_PKRSYtG0QrtffPUsESfnGkdfHdUsSigMjX5s5En8fLCGiNSQF2uyYREDFE6T0w5P3W5MR_Scloyhik1q7nv91PzlJ6Rn9_0F12zjzvPMTt7bobTdokaFVPcqjFWHJc4YCw-bzdBCxtzHxf3oVXeJzCzPNb_nOehZu-u7ue54NbYwcoZ_bokmsjCnQbFE_QA";
+        let token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJhcHBJZC0xNTA0Njg1OTYxMDAwIn0.eyJpc3MiOiJhcHBpZC1vYXV0aC5uZy5ibHVlbWl4Lm5ldCIsImF1ZCI6IjUzOGU4NTI2YTcwNDdjMWM5ZTEzNDZhYzQ1MjA2NmQxYmE1ZmQzNTEiLCJleHAiOjE1MTgxOTkzNTgsInRlbmFudCI6ImQ3YmMzMjJjLWIyMjQtNDFjMS05MWVhLWZjNjM4YWUyYWQ0ZCIsImlhdCI6MTUxODE5NTc1OCwiZW1haWwiOiJhYXJvbi5saWJlcmF0b3JlQGdtYWlsLmNvbSIsIm5hbWUiOiJBYXJvbiBMaWJlcmF0b3JlIiwicGljdHVyZSI6Imh0dHBzOi8vbGgzLmdvb2dsZXVzZXJjb250ZW50LmNvbS8tWGRVSXFkTWtDV0EvQUFBQUFBQUFBQUkvQUFBQUFBQUFBQUEvNDI1MnJzY2J2NU0vcGhvdG8uanBnIiwic3ViIjoiNGZiOTY0NDUtMGIzYy00Mzg2LWI3MmEtNTk2YmIzYTlkNDUwIiwiaWRlbnRpdGllcyI6W3sicHJvdmlkZXIiOiJnb29nbGUiLCJpZCI6IjEwODQ2MDkwMTMxMTMxNzgyOTg4NCJ9XSwiYW1yIjpbImdvb2dsZSJdLCJvYXV0aF9jbGllbnQiOnsibmFtZSI6IldhdHNvbiBUb25lIEFuYWx5emVyIFJLQUpHIiwidHlwZSI6Im1vYmlsZWFwcCIsInNvZnR3YXJlX2lkIjoiY29tLmlibS5XYXRzb25Ub25lQW5hbHl6ZXJSS0FKRyIsInNvZnR3YXJlX3ZlcnNpb24iOiIxLjAiLCJkZXZpY2VfaWQiOiI3QTk2QjJDQi1DNkI4LTRCNTYtQjA0Ri1FMTMwQjZDMkUxMUMiLCJkZXZpY2VfbW9kZWwiOiJpUGhvbmUiLCJkZXZpY2Vfb3MiOiJpT1MiLCJkZXZpY2Vfb3NfdmVyc2lvbiI6IjExLjIifX0.RTK5wV0b0mtbRayKg9IdGCnGXoA7bn4Gdx-YIQjaaELWJwpla2x1R1hMvL5It-MKMt_pyejzkdoTKR3v_VF4IMwnBWz83d0u6TVs28TbrgHAkXy6sAypIfEKc4gLOSHXkUBYREH2pbJSguxZNTwqKe_PKRSYtG0QrtffPUsESfnGkdfHdUsSigMjX5s5En8fLCGiNSQF2uyYREDFE6T0w5P3W5MR_Scloyhik1q7nv91PzlJ6Rn9_0F12zjzvPMTt7bobTdokaFVPcqjFWHJc4YCw-bzdBCxtzHxf3oVXeJzCzPNb_nOehZu-u7ue54NbYwcoZ_bokmsjCnQbFE_QA"
         
         let tokenParts = token.split(separator: ".")
         // JWT token should have 3 parts
@@ -467,7 +499,12 @@ class CryptorRSATests: XCTestCase {
         // JWT also does base64url encoding, so make the proper replacements so its proper base64 encoding
         sig = sig.replacingOccurrences(of: "-", with: "+")
         sig = sig.replacingOccurrences(of: "_", with: "/")
-        let sigData = Data(base64Encoded: sig)!
+        
+        guard let sigData: Data = Data(base64Encoded: sig) else {
+            XCTFail()
+            return
+        }
+        
         XCTAssertNotNil(sigData)
         
         let message = CryptorRSA.createPlaintext(with: messageData)
@@ -476,7 +513,7 @@ class CryptorRSATests: XCTestCase {
         let signature = CryptorRSA.createSigned(with: sigData)
         XCTAssertNotNil(signature)
         
-        let verificationResult = try message.verify(with: tokenPublicKey!, signature: signature, algorithm: .sha256)
+        let verificationResult = try message.verify(with: tokenPublicKey, signature: signature, algorithm: .sha256)
         XCTAssertTrue(verificationResult)
     }
 

--- a/Tests/CryptorRSATests/CryptorRSATests.swift
+++ b/Tests/CryptorRSATests/CryptorRSATests.swift
@@ -203,7 +203,11 @@ class CryptorRSATests: XCTestCase {
 	
 	func test_publicKeysFromComplexPEMFileWorksCorrectly() {
 		
-		let input = CryptorRSATests.pemKeyString(name: "multiple-keys-testcase")
+        guard let input = CryptorRSATests.pemKeyString(name: "multiple-keys-testcase") else {
+            XCTFail()
+            return
+        }
+        
 		let keys = CryptorRSA.PublicKey.publicKeys(withPEM: input)
 		XCTAssertEqual(keys.count, 9)
 		
@@ -523,18 +527,18 @@ class CryptorRSATests: XCTestCase {
 		let description: String
 	}
 	
-	static public func pemKeyString(name: String) -> String {
+	static public func pemKeyString(name: String) -> String? {
 		
         guard let path = CryptorRSATests.getFilePath(for: name, ofType: "pem") else {
             XCTFail("Could not create pemKeyString")
-            return "Error"
+            return nil
         }
         
         XCTAssertNotNil(path)
         
         guard let returnValue: String = try? String(contentsOfFile: path.path, encoding: String.Encoding.utf8) else {
             XCTFail("Could not create returnValue")
-            return "Error"
+            return nil
         }
         
         XCTAssertNotNil(returnValue)
@@ -542,29 +546,42 @@ class CryptorRSATests: XCTestCase {
         return returnValue
 	}
 	
-	static public func derKeyData(name: String) -> Data {
+	static public func derKeyData(name: String) -> Data? {
 		
-        let path = CryptorRSATests.getFilePath(for: name, ofType: "der")
-        XCTAssertNotNil(path)
+        guard let path = CryptorRSATests.getFilePath(for: name, ofType: "der") else {
+            XCTFail("Could not get file path")
+            return nil
+        }
         
-        return (try! Data(contentsOf: URL(fileURLWithPath: path!.path)))
+        guard let returnValue: Data = try? Data(contentsOf: URL(fileURLWithPath: path.path)) else {
+            XCTFail("Could not create derKeyData")
+            return nil
+        }
+        
+        return returnValue
 	}
+    
+    enum MyError : Error {
+        case invalidPath()
+    }
 	
 	static public func publicKey(name: String) throws -> CryptorRSA.PublicKey {
 		
-        let path = CryptorRSATests.getFilePath(for: name, ofType: "pem")
-        XCTAssertNotNil(path)
+        guard let path = CryptorRSATests.getFilePath(for: name, ofType: "pem") else {
+            throw MyError.invalidPath()
+        }
         
-        let pemString = try String(contentsOf: path!, encoding: String.Encoding.ascii)
+        let pemString = try String(contentsOf: path, encoding: String.Encoding.ascii)
         return try CryptorRSA.createPublicKey(withPEM: pemString)
 	}
 	
 	static public func privateKey(name: String) throws -> CryptorRSA.PrivateKey {
 		
-        let path = CryptorRSATests.getFilePath(for: name, ofType: "pem")
-        XCTAssertNotNil(path)
+        guard let path = CryptorRSATests.getFilePath(for: name, ofType: "pem") else {
+            throw MyError.invalidPath()
+        }
         
-        let pemString = try String(contentsOf: path!, encoding: String.Encoding.ascii)
+        let pemString = try String(contentsOf: path, encoding: String.Encoding.ascii)
         return try CryptorRSA.createPrivateKey(withPEM: pemString)
 	}
 	


### PR DESCRIPTION
There is an issue where systems using an older version of OpenSSL are not able to build, due to a type mismatch. The PR links to a branch I have made of the OpenSSL module map which now has a wrapper around the method in question (EVP_DigestVerifyFinal) to stop Swift complaining due to a type mismatch.

When the OpenSSL branch is merged into master, I will update this PR to point to the release that contains the fix, rather than the branch. Opening this now so Travis can do some testing.