### PR TITLE
Fix for Ubuntu 14.04 and OpenSSL 1.0.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ import PackageDescription
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 	
     let CryptoLibUrl = "https://github.com/IBM-Swift/CommonCrypto.git"
-    let CryptoLibVersion: Version = "1.0.0"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.0")
 	
 #elseif os(Linux)
 	

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         )
     ],
 	dependencies: [
-        .package(url: CryptoLibUrl, from: CryptoLibVersion)
+        .package(url: CryptoLibUrl, CryptoLibVersion)
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -30,11 +30,7 @@ import PackageDescription
 #elseif os(Linux)
 	
 	let CryptoLibUrl = "https://github.com/IBM-Swift/OpenSSL.git"
-<<<<<<< HEAD
-    let CryptoLibVersion: Version = "1.0.0"
-=======
     let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.1")
->>>>>>> 6c68b9e... Updated dependency for new OpenSSL version
 	
 #else
 	

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,11 @@ import PackageDescription
 #elseif os(Linux)
 	
 	let CryptoLibUrl = "https://github.com/IBM-Swift/OpenSSL.git"
+<<<<<<< HEAD
     let CryptoLibVersion: Version = "1.0.0"
+=======
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.1")
+>>>>>>> 6c68b9e... Updated dependency for new OpenSSL version
 	
 #else
 	

--- a/Sources/CryptorRSA/CryptorRSA.swift
+++ b/Sources/CryptorRSA/CryptorRSA.swift
@@ -615,7 +615,7 @@ public class CryptorRSA {
 
                 // Unlike other return values above, this return indicates if signature verifies or not
                 rc = signature.data.withUnsafeBytes({ (sig: UnsafePointer<UInt8>) -> Int32 in
-                    return EVP_DigestVerifyFinal(md_ctx, sig, signature.data.count)
+                    return SSL_EVP_digestVerifyFinal_wrapper(md_ctx, sig, signature.data.count)
                 })
                 
                 return (rc == 1) ? true : false

--- a/Sources/CryptorRSA/CryptorRSA.swift
+++ b/Sources/CryptorRSA/CryptorRSA.swift
@@ -613,7 +613,11 @@ public class CryptorRSA {
                     throw Error(code: ERR_VERIFICATION_FAILED, reason: source + ": No OpenSSL error reported.")
                 }
 
-                // Unlike other return values above, this return indicates if signature verifies or not
+		// Wrapper for OpenSSL EVP_DigestVerifyFinal function defined in
+		// IBM-Swift/OpenSSL/shim.h, to provide compatibility with OpenSSL
+		// 1.0.1 and 1.0.2 on Ubuntu 14.04 and 16.04, respectively.
+
+		// Unlike other return values above, this return indicates if signature verifies or not
                 rc = signature.data.withUnsafeBytes({ (sig: UnsafePointer<UInt8>) -> Int32 in
                     return SSL_EVP_digestVerifyFinal_wrapper(md_ctx, sig, signature.data.count)
                 })

--- a/Sources/CryptorRSA/CryptorRSA.swift
+++ b/Sources/CryptorRSA/CryptorRSA.swift
@@ -613,12 +613,11 @@ public class CryptorRSA {
                     throw Error(code: ERR_VERIFICATION_FAILED, reason: source + ": No OpenSSL error reported.")
                 }
 
-		// Wrapper for OpenSSL EVP_DigestVerifyFinal function defined in
-		// IBM-Swift/OpenSSL/shim.h, to provide compatibility with OpenSSL
-		// 1.0.1 and 1.0.2 on Ubuntu 14.04 and 16.04, respectively.
-
-		// Unlike other return values above, this return indicates if signature verifies or not
+                // Unlike other return values above, this return indicates if signature verifies or not
                 rc = signature.data.withUnsafeBytes({ (sig: UnsafePointer<UInt8>) -> Int32 in
+                    // Wrapper for OpenSSL EVP_DigestVerifyFinal function defined in
+                    // IBM-Swift/OpenSSL/shim.h, to provide compatibility with OpenSSL
+                    // 1.0.1 and 1.0.2 on Ubuntu 14.04 and 16.04, respectively.
                     return SSL_EVP_digestVerifyFinal_wrapper(md_ctx, sig, signature.data.count)
                 })
                 


### PR DESCRIPTION
There is an issue where systems using an older version of OpenSSL are not able to build, due to a type mismatch. The PR links to a branch I have made of the OpenSSL module map which now has a wrapper around the method in question (EVP_DigestVerifyFinal) to stop Swift complaining due to a type mismatch.