### PR TITLE
Xcode 10 support

### DIFF
--- a/Package@Swift-4.0.swift
+++ b/Package@Swift-4.0.swift
@@ -1,0 +1,65 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+//
+//  Package.swift
+//  CryptorRSA
+//
+//  Copyright © 2017 IBM. All rights reserved.
+//
+// 	Licensed under the Apache License, Version 2.0 (the "License");
+// 	you may not use this file except in compliance with the License.
+// 	You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// 	Unless required by applicable law or agreed to in writing, software
+// 	distributed under the License is distributed on an "AS IS" BASIS,
+// 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// 	See the License for the specific language governing permissions and
+// 	limitations under the License.
+//
+
+import PackageDescription
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+	
+    let CryptoLibUrl = "https://github.com/IBM-Swift/CommonCrypto.git"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.0")
+	
+#elseif os(Linux)
+	
+	let CryptoLibUrl = "https://github.com/IBM-Swift/OpenSSL.git"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.1")
+	
+#else
+	
+	fatalError("Unsupported OS")
+	
+#endif
+
+let package = Package(
+	name: "CryptorRSA",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "CryptorRSA",
+            targets: ["CryptorRSA"]
+        )
+    ],
+	dependencies: [
+        .package(url: CryptoLibUrl, CryptoLibVersion)
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "CryptorRSA",
+            dependencies: []
+        ),
+        .testTarget(
+            name: "CryptorRSATests",
+            dependencies: ["CryptorRSA"]
+        )
+    ]
+)

--- a/Package@Swift-4.1.swift
+++ b/Package@Swift-4.1.swift
@@ -1,0 +1,65 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+//
+//  Package.swift
+//  CryptorRSA
+//
+//  Copyright © 2017 IBM. All rights reserved.
+//
+// 	Licensed under the Apache License, Version 2.0 (the "License");
+// 	you may not use this file except in compliance with the License.
+// 	You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// 	Unless required by applicable law or agreed to in writing, software
+// 	distributed under the License is distributed on an "AS IS" BASIS,
+// 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// 	See the License for the specific language governing permissions and
+// 	limitations under the License.
+//
+
+import PackageDescription
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+	
+    let CryptoLibUrl = "https://github.com/IBM-Swift/CommonCrypto.git"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.0")
+	
+#elseif os(Linux)
+	
+	let CryptoLibUrl = "https://github.com/IBM-Swift/OpenSSL.git"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.1")
+	
+#else
+	
+	fatalError("Unsupported OS")
+	
+#endif
+
+let package = Package(
+	name: "CryptorRSA",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "CryptorRSA",
+            targets: ["CryptorRSA"]
+        )
+    ],
+	dependencies: [
+        .package(url: CryptoLibUrl, CryptoLibVersion)
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "CryptorRSA",
+            dependencies: []
+        ),
+        .testTarget(
+            name: "CryptorRSATests",
+            dependencies: ["CryptorRSA"]
+        )
+    ]
+)

--- a/Package@Swift-4.swift
+++ b/Package@Swift-4.swift
@@ -1,0 +1,58 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+//
+//  Package.swift
+//  CryptorRSA
+//
+//  Copyright © 2017 IBM. All rights reserved.
+//
+// 	Licensed under the Apache License, Version 2.0 (the "License");
+// 	you may not use this file except in compliance with the License.
+// 	You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// 	Unless required by applicable law or agreed to in writing, software
+// 	distributed under the License is distributed on an "AS IS" BASIS,
+// 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// 	See the License for the specific language governing permissions and
+// 	limitations under the License.
+//
+
+import PackageDescription
+
+var dependencies: [Package.Dependency] = []
+var targetDependencies: [Target.Dependency] = []
+
+	
+#if os(Linux)
+	
+dependencies.append(Package.Dependency.package(url: "https://github.com/IBM-Swift/OpenSSL.git", .upToNextMajor(from: "1.0.1")))
+    targetDependencies.append(Target.Dependency.byName(name: "OpenSSL"))
+	
+#endif
+
+let package = Package(
+	name: "CryptorRSA",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "CryptorRSA",
+            targets: ["CryptorRSA"]
+        )
+    ],
+	dependencies: dependencies,
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "CryptorRSA",
+            dependencies: targetDependencies
+        ),
+        .testTarget(
+            name: "CryptorRSATests",
+            dependencies: ["CryptorRSA"]
+        )
+    ]
+)


### PR DESCRIPTION
## Description
Module maps that are imported twice in Xcode 10 result in build errors in the app, but they still compile on the command line. To resolve this, if someone is running Swift 4.2 we don't require the common crypto dependency on macOS, as they will be on Xcode 10 and will already have it.
