### PR TITLE
Feat: Add iOS deployment target to podspec

### DIFF
--- a/BlueRSA.podspec
+++ b/BlueRSA.podspec
@@ -9,6 +9,7 @@ s.module_name  = 'CryptorRSA'
 
 s.requires_arc = true
 s.osx.deployment_target = "10.12"
+s.ios.deployment_target = "10.0"
 s.source   = { :git => "https://github.com/IBM-Swift/BlueRSA.git", :tag => s.version }
 s.source_files = "Sources/CryptorRSA/*.swift"
 s.pod_target_xcconfig =  {


### PR DESCRIPTION
## Description
This pull requests adds iOS 10 deployment target to podspec. This allows the pod to be built on iOS.

## Motivation and Context
This is a fix for issue #27. It allows you to import BlueRSA using cocoapods on iOS.

## How Has This Been Tested?
I have run created a podfile using this fork on iOS and it successfully installs the pod.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
