### PR TITLE
Swift 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
       osx_image: xcode9.2
@@ -43,6 +48,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/CryptorRSA/CryptorRSADigest.swift
+++ b/Sources/CryptorRSA/CryptorRSADigest.swift
@@ -32,7 +32,7 @@ import Foundation
 ///
 /// Digest Handling Extension
 ///
-public extension Data {
+extension Data {
 	
 	// MARK: Enums
 	

--- a/Sources/CryptorRSA/CryptorRSAErrors.swift
+++ b/Sources/CryptorRSA/CryptorRSAErrors.swift
@@ -24,7 +24,7 @@ import Foundation
 // MARK: -
 
 @available(macOS 10.12, iOS 10.0, *)
-public extension CryptorRSA {
+extension CryptorRSA {
 	
 	// MARK: Constants
 	
@@ -98,7 +98,7 @@ public extension CryptorRSA {
 		///
 		/// - Returns: Error instance
 		///
-		init(code: Int, reason: String?) {
+		public init(code: Int, reason: String?) {
 			
 			self.errorCode = Int32(code)
 			self.errorReason = reason

--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -30,7 +30,7 @@ import Foundation
 // MARK: -
 
 @available(macOS 10.12, iOS 10.0, *)
-public extension CryptorRSA {
+extension CryptorRSA {
 	
 	// MARK: Type Aliases
 	
@@ -38,17 +38,17 @@ public extension CryptorRSA {
 	
 		#if swift(>=4.2)
 	
-			typealias NativeKey = OpaquePointer?
+			public typealias NativeKey = OpaquePointer?
 	
 		#else
 	
-			typealias NativeKey = UnsafeMutablePointer<RSA>
+			public typealias NativeKey = UnsafeMutablePointer<RSA>
 	
 		#endif
 	
 	#else
 	
-		typealias NativeKey = SecKey
+		public typealias NativeKey = SecKey
 	
 	#endif
 	


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a build against a Swift 5 development snapshot to Travis, and resolves Swift 5 compilation warnings.

The compiler now emits a warning if a redundant access control modifier is applied to a member of an extension.  This comes about if you declare an explicit access control modifier on the extension itself (ie. `public extension Foo`) and also on members (`public var Bar`).

There are two choices:  keep the default access modifier on the extension (and remove `public` from all members of the extension), or remove the default access modifier and ensure all members that should be `public` are marked as such.

I've chosen the latter, as I think it makes it more clear as to what forms part of our public API: things that are public are still marked as such.

(note: my understanding is that removing the `public` from the extension only affects the _default_ visibility of its members. Public members of the extension remain public.  See: https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html#ID25)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
