### PR TITLE
fix: Add PEM header for base64 private key on linux

### DIFF
--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -428,11 +428,21 @@ extension CryptorRSA {
 	///
 	public class func createPrivateKey(withBase64 base64String: String) throws -> PrivateKey {
 		
-		guard let data = Data(base64Encoded: base64String, options: [.ignoreUnknownCharacters]) else {
+		guard let dataIn = Data(base64Encoded: base64String, options: [.ignoreUnknownCharacters]) else {
 			
 			throw Error(code: ERR_INIT_PK, reason: "Couldn't decode base 64 string")
 		}
-		
+        
+        #if os(Linux)
+        
+        let data = CryptorRSA.convertDerToPem(from: dataIn, type: .privateType)
+        
+        #else
+        
+        let data = dataIn
+        
+        #endif
+
 		return try PrivateKey(with: data)
 	}
 	

--- a/Tests/CryptorRSATests/CryptorRSATests.swift
+++ b/Tests/CryptorRSATests/CryptorRSATests.swift
@@ -267,6 +267,21 @@ class CryptorRSATests: XCTestCase {
             XCTAssertTrue(privateKey!.type == .privateType)
         }
 	}
+    
+    func test_private_initWithBase64() throws {
+        
+        let path = CryptorRSATests.getFilePath(for: "private", ofType: "pem")
+        XCTAssertNotNil(path)
+        
+        if let filePath = path {
+            let str = try String(contentsOf: filePath, encoding: .utf8)
+            let strippedstr = String(str.filter { !" \n\t\r".contains($0) })
+            let headerlessStr = String(strippedstr.dropFirst(28).dropLast(26))
+            let privateKey = try? CryptorRSA.createPrivateKey(withBase64: headerlessStr)
+            XCTAssertNotNil(privateKey)
+            XCTAssertTrue(privateKey?.type == .privateType)
+        }
+    }
 	
 	func test_private_initWithPEMStringHeaderless() throws {
 		
@@ -721,7 +736,7 @@ cSNAr2BBC8bJ9AfZnRu9+Y1/VyXY91R95bQoMFfgwZdMUEyuL5gG524QplqF
             ("test_public_initWithCertificateName", test_public_initWithCertificateName),
             ("test_public_initWithCertificateName2", test_public_initWithCertificateName2),
             ("test_private_initWithPEMString", test_private_initWithPEMString),
-
+            ("test_private_initWithBase64", test_private_initWithBase64),
 //			("test_private_initWithPEMStringHeaderless", test_private_initWithPEMStringHeaderless),
             ("test_private_initWithPEMName", test_private_initWithPEMName),
             ("test_private_initWithDERName", test_private_initWithDERName),


### PR DESCRIPTION
If you tried to create a private key using a base64 encoded String it would crash on linux. This was because the OpenSSL interface we are using takes a PEM key and we were not adding the required headers. 

This PR fixes this issue and adds a test case to cover the expected behaviour.