### PR TITLE
Update iOS available version to 10.3

### DIFF
--- a/Sources/CryptorRSA/CryptorRSA.swift
+++ b/Sources/CryptorRSA/CryptorRSA.swift
@@ -32,7 +32,7 @@ import Foundation
 ///
 /// RSA Encryption/Decryption, Signing/Verification
 ///
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.3, *)
 public class CryptorRSA {
 	
 	// MARK: Class Functions

--- a/Sources/CryptorRSA/CryptorRSA.swift
+++ b/Sources/CryptorRSA/CryptorRSA.swift
@@ -32,7 +32,7 @@ import Foundation
 ///
 /// RSA Encryption/Decryption, Signing/Verification
 ///
-@available(macOS 10.12, iOS 10.3, *)
+@available(macOS 10.12, iOS 10.3, watchOS 3.3, tvOS 12.0, *)
 public class CryptorRSA {
 	
 	// MARK: Class Functions

--- a/Sources/CryptorRSA/CryptorRSAConstants.swift
+++ b/Sources/CryptorRSA/CryptorRSAConstants.swift
@@ -23,7 +23,7 @@ import Foundation
 
 // MARK: -
 
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.3, *)
 public extension CryptorRSA {
 	
 	// MARK: Constants

--- a/Sources/CryptorRSA/CryptorRSAConstants.swift
+++ b/Sources/CryptorRSA/CryptorRSAConstants.swift
@@ -23,7 +23,7 @@ import Foundation
 
 // MARK: -
 
-@available(macOS 10.12, iOS 10.3, *)
+@available(macOS 10.12, iOS 10.3, watchOS 3.3, tvOS 12.0, *)
 public extension CryptorRSA {
 	
 	// MARK: Constants

--- a/Sources/CryptorRSA/CryptorRSADigest.swift
+++ b/Sources/CryptorRSA/CryptorRSADigest.swift
@@ -168,7 +168,7 @@ extension Data {
 
         #else
 			
-			@available(macOS 10.12, iOS 10.0, *)
+			@available(macOS 10.12, iOS 10.3, *)
 			public var algorithmForSignature: SecKeyAlgorithm {
 					
 				switch self {
@@ -218,7 +218,7 @@ extension Data {
 				}
 			}
 				
-			@available(macOS 10.12, iOS 10.0, *)
+			@available(macOS 10.12, iOS 10.3, *)
 			public var alogrithmForEncryption: SecKeyAlgorithm {
 			
 				switch self {

--- a/Sources/CryptorRSA/CryptorRSADigest.swift
+++ b/Sources/CryptorRSA/CryptorRSADigest.swift
@@ -168,7 +168,7 @@ extension Data {
 
         #else
 			
-			@available(macOS 10.12, iOS 10.3, *)
+			@available(macOS 10.12, iOS 10.0, *)
 			public var algorithmForSignature: SecKeyAlgorithm {
 					
 				switch self {
@@ -218,7 +218,7 @@ extension Data {
 				}
 			}
 				
-			@available(macOS 10.12, iOS 10.3, *)
+			@available(macOS 10.12, iOS 10.0, *)
 			public var alogrithmForEncryption: SecKeyAlgorithm {
 			
 				switch self {

--- a/Sources/CryptorRSA/CryptorRSADigest.swift
+++ b/Sources/CryptorRSA/CryptorRSADigest.swift
@@ -168,7 +168,7 @@ extension Data {
 
         #else
 			
-			@available(macOS 10.12, iOS 10.0, *)
+			@available(macOS 10.12, iOS 10.0, watchOS 3.3, tvOS 12.0, *)
 			public var algorithmForSignature: SecKeyAlgorithm {
 					
 				switch self {
@@ -218,7 +218,7 @@ extension Data {
 				}
 			}
 				
-			@available(macOS 10.12, iOS 10.0, *)
+			@available(macOS 10.12, iOS 10.0, watchOS 3.3, tvOS 12.0, *)
 			public var alogrithmForEncryption: SecKeyAlgorithm {
 			
 				switch self {

--- a/Sources/CryptorRSA/CryptorRSAErrors.swift
+++ b/Sources/CryptorRSA/CryptorRSAErrors.swift
@@ -23,7 +23,7 @@ import Foundation
 
 // MARK: -
 
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.3, *)
 extension CryptorRSA {
 	
 	// MARK: Constants

--- a/Sources/CryptorRSA/CryptorRSAErrors.swift
+++ b/Sources/CryptorRSA/CryptorRSAErrors.swift
@@ -23,7 +23,7 @@ import Foundation
 
 // MARK: -
 
-@available(macOS 10.12, iOS 10.3, *)
+@available(macOS 10.12, iOS 10.3, watchOS 3.3, tvOS 12.0, *)
 extension CryptorRSA {
 	
 	// MARK: Constants

--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -320,12 +320,14 @@ extension CryptorRSA {
 			}
 			
 			var key: SecKey? = nil
-		
+			#if swift(>=4.2)
 			if #available(macOS 10.14, iOS 12.0, watchOS 5.0, *) {
 				
 				key = SecCertificateCopyKey(certData)
-					
-			} else {
+				
+			} 
+			#endif
+			if key == nil {
 		
 			#if os(macOS)
 		

--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -29,7 +29,7 @@ import Foundation
 
 // MARK: -
 
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.3, *)
 extension CryptorRSA {
 	
 	// MARK: Type Aliases

--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -29,7 +29,7 @@ import Foundation
 
 // MARK: -
 
-@available(macOS 10.12, iOS 10.3, *)
+@available(macOS 10.12, iOS 10.3, watchOS 3.3, tvOS 12.0, *)
 extension CryptorRSA {
 	
 	// MARK: Type Aliases
@@ -321,7 +321,7 @@ extension CryptorRSA {
 			
 			var key: SecKey? = nil
 		
-			if #available(macOS 10.14, iOS 12.0, *) {
+			if #available(macOS 10.14, iOS 12.0, watchOS 5.0, *) {
 				
 				key = SecCertificateCopyKey(certData)
 					

--- a/Sources/CryptorRSA/CryptorRSAUtilities.swift
+++ b/Sources/CryptorRSA/CryptorRSAUtilities.swift
@@ -32,7 +32,7 @@ import Foundation
 ///
 /// Various RSA Related Utility Functions
 ///
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.3, *)
 public extension CryptorRSA {
 	
 #if os(Linux)

--- a/Sources/CryptorRSA/CryptorRSAUtilities.swift
+++ b/Sources/CryptorRSA/CryptorRSAUtilities.swift
@@ -32,7 +32,7 @@ import Foundation
 ///
 /// Various RSA Related Utility Functions
 ///
-@available(macOS 10.12, iOS 10.3, *)
+@available(macOS 10.12, iOS 10.3, watchOS 3.3, tvOS 12.0, *)
 public extension CryptorRSA {
 	
 #if os(Linux)

--- a/Tests/CryptorRSATests/CryptorRSATests.swift
+++ b/Tests/CryptorRSATests/CryptorRSATests.swift
@@ -26,7 +26,7 @@ import XCTest
 
 @testable import CryptorRSA
 
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.3, *)
 class CryptorRSATests: XCTestCase {
 	
 	/// Test for bundle usage.

--- a/Tests/CryptorRSATests/CryptorRSATests.swift
+++ b/Tests/CryptorRSATests/CryptorRSATests.swift
@@ -26,7 +26,7 @@ import XCTest
 
 @testable import CryptorRSA
 
-@available(macOS 10.12, iOS 10.3, *)
+@available(macOS 10.12, iOS 10.3, watchOS 3.3, tvOS 12.0, *)
 class CryptorRSATests: XCTestCase {
 	
 	/// Test for bundle usage.


### PR DESCRIPTION
## Description
A user was trying to build Swfit-JWT using Carthage and it wouldn't compile.
They raised issue [#64](https://github.com/IBM-Swift/Swift-JWT/issues/64) which shows the compile error that:

```
'SecCertificateCopyPublicKey' is only available on iOS 10.3 or newer
```
This fix updates the @available tag to be:
```
@available(macOS 10.12, iOS 10.3, *)
```

Which allows the project to compile.

## How Has This Been Tested?

The project was compiled and tested using the iOS simulator.
