### PR TITLE
ci: Enable Xcode11 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,10 @@ matrix:
     - os: osx
       osx_image: xcode10.2
       sudo: required
-# Pending Travis Xcode 11 image
-#    - os: osx
-#      osx_image: xcode11
-#      sudo: required
-#      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: osx
+      osx_image: xcode11
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/CryptorRSA/CryptorRSAUtilities.swift
+++ b/Sources/CryptorRSA/CryptorRSAUtilities.swift
@@ -231,7 +231,7 @@ public extension CryptorRSA {
 			throw Error(code: ERR_STRIP_PK_HEADER, reason: "Provided public key is empty")
 		}
 		
-		var byteArray = [UInt8](keyData)
+		let byteArray = [UInt8](keyData)
 		
 		var index = 0
 		guard byteArray[index] == 0x30 else {


### PR DESCRIPTION
Travis recently published an `xcode11` macOS image.  This enables the macOS 5.1 CI testing.
Also resolve a compile warning.