### PR TITLE
Compatability changes for Catalyst

### DIFF
--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -349,7 +349,7 @@ extension CryptorRSA {
 			
 				#else
 			
-					key = SecCertificateCopyPublicKey(certData)
+					key = SecCertificateCopyKey(certData)
 			
 				#endif
 			}

--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -349,7 +349,11 @@ extension CryptorRSA {
 			
 				#else
 			
-					key = SecCertificateCopyKey(certData)
+					if #available(iOS 12, *) {
+						key = SecCertificateCopyKey(certData)
+					} else {
+						key = SecCertificateCopyPublicKey(certData)
+					}
 			
 				#endif
 			}


### PR DESCRIPTION
In order to use this package in catalyst projects SecCertificateCopyPublicKey was deprecated and needed to change to the supported Method `SecCertificateCopyKey(certData)` Method.

## Description
In order to use this package in catalyst projects SecCertificateCopyPublicKey was deprecated and needed to change to the supported Method `SecCertificateCopyKey(certData)` Method.

Resources: 
Deprecation - https://developer.apple.com/documentation/security/1396096-seccertificatecopypublickey
New Method - https://developer.apple.com/documentation/security/2963103-seccertificatecopykey

## Motivation and Context
I'd like to use it in my macOS, iPadOS and iOS project suppored by Catalyst.

## How Has This Been Tested?
I have a project which has iOS, iPadOS and macOS as deployment targets.
I use the deployment version iOS 13.1 and macOS 10.15 (catalina).
The dependency management is Swift Package Manager.
My dynamic framwork has the SwiftJWT package as dependency and uses BlueRSA in order to create the JWT.

Building and running the project on iOS works fine but macOS catalyst does not know the deprecated method `SecCertificateCopyPublicKey`. Since catalyst the new method `SecCertificateCopyKey` has to be used in order to support catalyst.

Resources: 
Deprecation - https://developer.apple.com/documentation/security/1396096-seccertificatecopypublickey
New Method - https://developer.apple.com/documentation/security/2963103-seccertificatecopykey

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
(Just changed to the new method and remove the deprecation.)
- [x] If applicable, I have updated the documentation accordingly.
(no changes necessary)
- [x] If applicable, I have added tests to cover my changes.
(see above)
