### PR TITLE
Use SecCertificateCopyKey API when available, falling back in edge cases

### DIFF
--- a/CryptorRSA.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/CryptorRSA.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CryptorRSA.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CryptorRSA.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -322,27 +322,7 @@ extension CryptorRSA {
 			
 			var key: SecKey? = nil
         
-            #if swift(<4.2)
-                #if os(macOS)
-
-                    // Now extract the public key from it...
-                    let status: OSStatus = withUnsafeMutablePointer(to: &key) { ptr in
-                        
-                        // Retrieves the public key from a certificate...
-                        SecCertificateCopyPublicKey(certData, UnsafeMutablePointer(ptr))
-                    }
-
-                    if status != errSecSuccess {
-            
-                        throw Error(code: ERR_EXTRACT_PUBLIC_KEY_FAILED, reason: "Unable to extract public key from data.")
-                    }
-
-                #else
-                   
-                    key = SecCertificateCopyPublicKey(certData)
-
-                #endif
-            #else
+            #if swift(>=4.2)
                 #if os(macOS)
                     if #available(macOS 10.14, *) {
                         key = SecCertificateCopyKey(certData)
@@ -373,6 +353,26 @@ extension CryptorRSA {
                     #endif
                     
                     key = copyKey(certData)
+                #endif
+            #else
+                #if os(macOS)
+
+                    // Now extract the public key from it...
+                    let status: OSStatus = withUnsafeMutablePointer(to: &key) { ptr in
+                        
+                        // Retrieves the public key from a certificate...
+                        SecCertificateCopyPublicKey(certData, UnsafeMutablePointer(ptr))
+                    }
+
+                    if status != errSecSuccess {
+            
+                        throw Error(code: ERR_EXTRACT_PUBLIC_KEY_FAILED, reason: "Unable to extract public key from data.")
+                    }
+
+                #else
+                   
+                    key = SecCertificateCopyPublicKey(certData)
+
                 #endif
             #endif
 		


### PR DESCRIPTION
`SecCertificateCopyPublicKey` is deprecated in iOS 12 and macOS 10.14 in favor of `SecCertificateCopyKey`. This change introduces the use of the new API for all platforms that support it.

## Description
Simply uses the new API when available and falls back to the legacy API when not. Keeps support for pre-4.2 Swift, but wraps everything in compiler directives to allow builds on platforms that have no reference to the deprecated API.

The changes to the xcode project are from opening the project in a newer version of XCode. Content from 9.3 release notes:
> Xcode 9.3 adds a new IDEWorkspaceChecks.plist file to a workspace's shared data, to store the state of necessary workspace checks. Committing this file to source control will prevent unnecessary rerunning of those checks for each user opening the workspace. (37293167)

## Motivation and Context
Previous to this patch, BlueRSA did not compile on macOS Catalyst. There is an existing pull request open, but the author has not responded in some time. Moreover, it appears `SecCertificateCopyKey` is already used for clients that support it, however, the codepath using the deprecated API was not wrapped in a compiler directive and the compiler still failed.

Resolves #59

## How Has This Been Tested?
Built and run on macOS and iOS. Ran tests on the macOS target.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
