### PR TITLE
Only strip pkcs8 header for Private Keys (Fixes Issue #85)

### DIFF
--- a/Sources/CryptorRSA/CryptorRSAKey.swift
+++ b/Sources/CryptorRSA/CryptorRSAKey.swift
@@ -659,7 +659,7 @@ extension CryptorRSA {
 				let base64Data = Data(base64Encoded: base64String) {
 				data = base64Data
 			}
-			data = try CryptorRSA.stripX509CertificateHeader(for: data)
+			data = try CryptorRSA.stripX509CertificateHeader(for: data, type: type)
 			self.pemString = CryptorRSA.convertDerToPem(from: data, type: type)
 			self.type = type            
             reference = try CryptorRSA.createKey(from: data, type: type)
@@ -777,7 +777,7 @@ extension CryptorRSA {
 					guard let derData = Data(base64Encoded: derString) else {
 						throw Error(code: ERR_INIT_PK, reason: "Couldn't read PEM String")
 					}
-					let strippedDer = try CryptorRSA.stripX509CertificateHeader(for: derData)
+					let strippedDer = try CryptorRSA.stripX509CertificateHeader(for: derData, type: keyType)
 					let pkcs1PEM = CryptorRSA.convertDerToPem(from: strippedDer, type: keyType)
 					return pkcs1PEM
 				}

--- a/Sources/CryptorRSA/CryptorRSAUtilities.swift
+++ b/Sources/CryptorRSA/CryptorRSAUtilities.swift
@@ -219,10 +219,10 @@ public extension CryptorRSA {
 	///
 	/// - Returns:					`Data` containing the public with header (if present) removed.
 	///
-	static func stripX509CertificateHeader(for keyData: Data) throws -> Data {
+	static func stripX509CertificateHeader(for keyData: Data, type: CryptorRSA.RSAKey.KeyType) throws -> Data {
 		
 		// If private key in pkcs8 format, strip the header
-		if keyData[26] == 0x30 {
+        if keyData[26] == 0x30 && type == .privateType {
 			return(keyData.advanced(by: 26))
 		}
 		

--- a/Tests/CryptorRSATests/CryptorRSATests.swift
+++ b/Tests/CryptorRSATests/CryptorRSATests.swift
@@ -807,7 +807,7 @@ AqJRAgMBAAE=
 		let data1 = Data(base64Encoded: pemString) ?? Data()
 		print("data1 count=\(data1.count)")
 		do {
-			let pubKey = try CryptorRSA.createPublicKey(withPEM: pemString)
+			let _ = try CryptorRSA.createPublicKey(withPEM: pemString)
 			print("pemString1 successful")
 		} catch {
 			XCTFail("Error creating public key from pemString: \(error)")


### PR DESCRIPTION
* Also address build warning about an unused variable

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix unit test failure due to stripping the header of all pkcs8 keys - instead of JUST the private keys.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Seeing a unit test failure in Xcode 15 & 16, when targeting Mac or iPhone Simulator.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified successful unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
